### PR TITLE
add hint how to enable input line in Browser Console

### DIFF
--- a/index.html
+++ b/index.html
@@ -15,12 +15,13 @@ So if you really need to mass-update your password, do this:<p>
 <li>Right click on the input line at the bottom and paste the code there, and press Enter. You will be asked further there for password change.
 </ul>
 
+If the input line at the bottom is not visible, you need to go to about:config and change the <code>devtools.chrome.enabled</code> preference to <code>true</code>.
+
 <i>dmitry@karasik.eu.org</i>
 
 <p>
 <form><input type="button" id="button" value="Generate Script"></form>
 <script src="opt.js"></script>
-
 
 </body>
 </html>


### PR DESCRIPTION
Thank you very much for your nice extension.  In the last Firefox upgrade the input line in the Browser Console got disabled by default it seems:  https://developer.mozilla.org/en-US/docs/Tools/Browser_Console

Took me a bit to figure it out so I thought to just add a hint for the next person to stumble over it.